### PR TITLE
Fix accounting

### DIFF
--- a/Acquire/Accounting/_account.py
+++ b/Acquire/Accounting/_account.py
@@ -756,9 +756,13 @@ class Account:
 
         user_guid = None
 
+        identifiers = None
+
         if not authorisation.is_null():
-            authorisation.verify(resource=resource,
-                                 accept_partial_match=accept_partial_match)
+            identifiers = authorisation.verify(
+                                 resource=resource,
+                                 accept_partial_match=accept_partial_match,
+                                 return_identifiers=True)
             user_guid = authorisation.user_guid()
 
         upstream = None
@@ -767,11 +771,11 @@ class Account:
             from Acquire.Accounting import Accounts as _Accounts
             group = _Accounts(user_guid=user_guid, group=self.group_name())
             upstream = group.aclrules().resolve(must_resolve=False,
-                                                user_guid=user_guid)
+                                                identifiers=identifiers)
 
         aclrule = self._aclrules.resolve(must_resolve=True,
                                          upstream=upstream,
-                                         user_guid=user_guid)
+                                         identifiers=identifiers)
 
         if not aclrule.is_writeable():
             raise PermissionError(

--- a/Acquire/Accounting/_accounts.py
+++ b/Acquire/Accounting/_accounts.py
@@ -77,6 +77,12 @@ class Accounts:
 
         self._aclrules = aclrules
 
+    def identifiers(self):
+        """Return the set of validated identifiers that are known to
+           be attached to this group of accounts
+        """
+        return {"user_guid": self._user_guid}
+
     def aclrules(self):
         """Return the ACL rules for this group of accounts"""
         return self._aclrules
@@ -106,7 +112,7 @@ class Accounts:
     def _assert_is_readable(self):
         """Assert that we have permission to read these accounts"""
         aclrule = self._aclrules.resolve(must_resolve=True,
-                                         user_guid=self._user_guid)
+                                         identifiers=self.identifiers())
 
         if not aclrule.is_readable():
             raise PermissionError(
@@ -116,7 +122,7 @@ class Accounts:
     def _assert_is_writeable(self):
         """Assert that we have permission to write these accounts"""
         aclrule = self._aclrules.resolve(must_resolve=True,
-                                         user_guid=self._user_guid)
+                                         identifiers=self.identifiers())
 
         if not aclrule.is_writeable():
             raise PermissionError(

--- a/Acquire/Client/_drive.py
+++ b/Acquire/Client/_drive.py
@@ -210,7 +210,7 @@ class Drive:
         return par
 
     def upload(self, filename, uploaded_name=None, aclrules=None,
-               **kwargs):
+               force_par=False):
         """Upload the file at 'filename' to this drive, assuming we have
            write access to this drive. The local file 'filename' will be
            uploaded to the drive as the file called 'filename' (just the
@@ -236,14 +236,13 @@ class Drive:
 
         local_cutoff = None
 
-        if "force_par" in kwargs:
-            if kwargs["force_par"]:
-                local_cutoff = 0
+        if force_par:
+            # only upload using a PAR
+            local_cutoff = 0
 
         filehandle = _FileHandle(filename=filename,
                                  remote_filename=uploaded_name,
                                  drive_uid=self.uid(),
-                                 user_guid=self._user.guid(),
                                  aclrules=aclrules,
                                  local_cutoff=local_cutoff)
 
@@ -283,7 +282,7 @@ class Drive:
             raise
 
     def download(self, filename, downloaded_name=None, version=None,
-                 dir=None, **kwargs):
+                 dir=None, force_par=False):
         """Download the file called 'filename' from this drive into
            the local directory, or 'dir' if specified,
            ideally called 'filename'
@@ -326,8 +325,8 @@ class Drive:
                 "authorisation": authorisation.to_data(),
                 "encryption_key": privkey.public_key().to_data()}
 
-        if "force_par" in kwargs:
-            args["force_par"] = kwargs["force_par"]
+        if force_par:
+            args["force_par"] = True
 
         if version is not None:
             from Acquire.ObjectStore import datetime_to_string \

--- a/Acquire/Client/_filehandle.py
+++ b/Acquire/Client/_filehandle.py
@@ -78,8 +78,8 @@ class FileHandle:
                 # will be automatically set to 'inherit' on the service
                 self._aclrules = None
             else:
-                from Acquire.Storage import create_aclrules as _create_aclrules
-                self._aclrules = _create_aclrules(aclrules=aclrules)
+                from Acquire.Identity import ACLRules as _ACLRules
+                self._aclrules = _ACLRules.create(rule=aclrules)
 
             from Acquire.Access import get_filesize_and_checksum \
                 as _get_filesize_and_checksum

--- a/Acquire/Client/_filehandle.py
+++ b/Acquire/Client/_filehandle.py
@@ -50,7 +50,7 @@ class FileHandle:
        hot and cold storage or pay for extended storage
     """
     def __init__(self, filename=None, remote_filename=None,
-                 aclrules=None, drive_uid=None, user_guid=None,
+                 aclrules=None, drive_uid=None,
                  compress=True, local_cutoff=None):
         """Construct a handle for the local file 'filename'. This will
            create the initial version of the file that can be uploaded
@@ -63,12 +63,9 @@ class FileHandle:
         self._compression = None
         self._compressed_filename = None
         self._drive_uid = drive_uid
-        self._user_guid = None
         self._aclrules = None
 
         if filename is not None:
-            self._user_guid = user_guid
-
             if local_cutoff is None:
                 local_cutoff = 1048576
             else:
@@ -196,10 +193,6 @@ class FileHandle:
         """Return the ACL rules for this file"""
         return self._aclrules
 
-    def user_guid(self):
-        """Return the GUID of the user who has opened/uploaded this file"""
-        return self._user_guid
-
     def filename(self):
         """Return the remote (object store) filename for this file"""
         return self._filename
@@ -244,7 +237,6 @@ class FileHandle:
                 data["aclrules"] = self._aclrules.to_data()
 
             data["drive_uid"] = self.drive_uid()
-            data["user_guid"] = self.user_guid()
 
             if self._local_filedata is not None:
                 from Acquire.ObjectStore import bytes_to_string \

--- a/Acquire/Identity/__init__.py
+++ b/Acquire/Identity/__init__.py
@@ -6,13 +6,13 @@ an Acquire Identity Service. The Identity Service is responsible for
 identifying and authenticating users.
 """
 
+from ._aclrule import *
+from ._aclrules import *
 from ._identity_service import *
 from ._loginsession import *
 from ._authorisation import *
 from ._useraccount import *
 from ._errors import *
-
-from Acquire.Storage import ACLRule, ACLRules
 
 try:
     if __IPYTHON__:

--- a/Acquire/Identity/_aclrule.py
+++ b/Acquire/Identity/_aclrule.py
@@ -350,7 +350,7 @@ class ACLRule:
 
         upstream = kwargs["upstream"]
 
-        from Acquire.Storage import ACLRules as _ACLRules
+        from Acquire.Identity import ACLRules as _ACLRules
         if isinstance(upstream, _ACLRules):
             del kwargs["upstream"]
             upstream = upstream.resolve(**kwargs)

--- a/Acquire/Identity/_aclrule.py
+++ b/Acquire/Identity/_aclrule.py
@@ -326,38 +326,28 @@ class ACLRule:
         return ACLRule(is_owner=is_owner, is_writeable=is_writeable,
                        is_readable=is_readable, is_executable=is_executable)
 
-    def resolve(self, must_resolve=True, **kwargs):
+    def resolve(self, must_resolve=True, identifiers=None,
+                upstream=None, unresolved=False):
         """Resolve these rules based on the information supplied
-           in 'kwargs'. Notably, if any of our rules are 'inherit',
-           the this will look for an ACLRule called "upstream" to
+           in 'identifiers'. Notably, if any of our rules are 'inherit',
+           the this will look into 'upstream' to
            inherit the rule. If 'must_resolve' is true, then
-           this function must always return
-           a fully-resolved ACLRule
+           this function must always return a fully-resolved ACLRule
+           (in which any unresolved parts are set equal to 'unresolved')
         """
         if self.is_fully_resolved():
             return self
 
-        if "unresolved" in kwargs:
-            unresolved = kwargs["unresolved"]
-        else:
-            unresolved = False
-
-        if ("upstream" not in kwargs) or kwargs["upstream"] is None:
+        if upstream is None:
             if must_resolve:
                 return self._force_resolve(unresolved=unresolved)
             else:
                 return self
 
-        upstream = kwargs["upstream"]
-
         from Acquire.Identity import ACLRules as _ACLRules
         if isinstance(upstream, _ACLRules):
-            del kwargs["upstream"]
-            upstream = upstream.resolve(**kwargs)
-
-        if not upstream.is_fully_resolved():
-            del kwargs["upstream"]
-            upstream = upstream.resolve(must_resolve=must_resolve, **kwargs)
+            upstream = upstream.resolve(must_resolve=False,
+                                        identifiers=identifiers)
 
         if must_resolve and (not upstream.is_fully_resolved()):
             upstream = upstream._force_resolve(unresolved=unresolved)
@@ -379,8 +369,13 @@ class ACLRule:
         if is_executable is None:
             is_executable = upstream._is_executable
 
-        return ACLRule(is_owner=is_owner, is_writeable=is_writeable,
-                       is_readable=is_readable, is_executable=is_executable)
+        result = ACLRule(is_owner=is_owner, is_writeable=is_writeable,
+                         is_readable=is_readable, is_executable=is_executable)
+
+        if must_resolve:
+            result = result._force_resolve(unresolved=unresolved)
+
+        return result
 
     def set_owner(self, is_owner=True):
         """Set the user as an owner of the bucket"""

--- a/Acquire/Identity/_aclrules.py
+++ b/Acquire/Identity/_aclrules.py
@@ -1,8 +1,7 @@
 
 from enum import Enum as _Enum
 
-__all__ = ["ACLRules", "ACLUserRules", "ACLGroupRules",
-           "create_aclrules"]
+__all__ = ["ACLRules", "ACLUserRules", "ACLGroupRules"]
 
 
 class ACLRuleOperation(_Enum):
@@ -36,59 +35,6 @@ class ACLRuleOperation(_Enum):
         return ACLRuleOperation(data)
 
 
-def create_aclrules(**kwargs):
-    """Create an ACLRules object the passed set of rules, for example
-
-        user_guid, aclrule  would set the aclrule for user to aclrule
-        group_guid, aclrule would set the aclrule for group to aclrule
-
-        default_rule  would set a default rule if nothing else matches
-    """
-    aclrules = None
-
-    if "aclrules" in kwargs:
-        aclrules = kwargs["aclrules"]
-
-        if not isinstance(aclrules, ACLRules):
-            aclrules = ACLRules(rule=aclrules)
-
-        if "default" in kwargs:
-            aclrules.set_default_rule(kwargs["default"])
-
-    if "aclrule" in kwargs:
-        from Acquire.Storage import ACLRule as _ACLRule
-
-        aclrule = kwargs["aclrule"]
-        if "user_guid" in kwargs:
-            if aclrules is None:
-                aclrules = ACLRules(default_rule=_ACLRule.denied())
-
-            user_rules = ACLUserRules()
-            user_rules.add_user_rule(kwargs["user_guid"], aclrule)
-            aclrules.append(user_rules)
-        elif "group_guid" in kwargs:
-            if aclrules is None:
-                aclrules = ACLRules(default_rule=_ACLRule.denied())
-
-            group_rules = ACLGroupRules()
-            group_rules.add_group_rule(kwargs["group_guid"], aclrule)
-            aclrules.append(group_rules)
-        else:
-            if isinstance(aclrule, ACLRules):
-                aclrules.append(aclrule)
-
-    if "default" in kwargs:
-        if aclrules is None:
-            aclrules = ACLRules(default_rule=kwargs["default"])
-        else:
-            aclrules.set_default(kwargs["default"])
-
-    if aclrules is None:
-        aclrules = ACLRules()
-
-    return aclrules
-
-
 def _save_rule(rule):
     """Return a json-serialisable object for the passed rule"""
     return [rule.__class__.__name__, rule.to_data()]
@@ -109,7 +55,7 @@ def _load_rule(rule):
     elif classname == "ACLGroupRules":
         return ACLGroupRules.from_data(classdata)
     elif classname == "ACLRule":
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
         return _ACLRule.from_data(classdata)
     else:
         raise TypeError("Unrecognised type '%s'" % classname)
@@ -151,7 +97,7 @@ class ACLGroupRules:
             rule = self._group_rules[group_guid]
             return rule.resolve(must_resolve=must_resolve, **kwargs)
         elif must_resolve:
-            from Acquire.Storage import ACLRule as _ACLRule
+            from Acquire.Identity import ACLRule as _ACLRule
             return _ACLRule.inherit().resolve(must_resolve=True, **kwargs)
         else:
             return None
@@ -216,7 +162,7 @@ class ACLUserRules:
             rule = self._user_rules[user_guid]
             return rule.resolve(must_resolve=must_resolve, **kwargs)
         elif must_resolve:
-            from Acquire.Storage import ACLRule as _ACLRule
+            from Acquire.Identity import ACLRule as _ACLRule
             return _ACLRule.inherit().resolve(must_resolve=True, **kwargs)
         else:
             return None
@@ -243,7 +189,7 @@ class ACLUserRules:
         """Simple shorthand to create the rule that the specified
            user is the owner of the resource
         """
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
         return ACLUserRules._create(aclrule=_ACLRule.owner(),
                                     user_guid=user_guid,
                                     user_guids=user_guids)
@@ -253,7 +199,7 @@ class ACLUserRules:
         """Simple shorthand to create the rule that the specified
            user is the executer of the resource
         """
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
         return ACLUserRules._create(aclrule=_ACLRule.executer(),
                                     user_guid=user_guid,
                                     user_guids=user_guids)
@@ -263,7 +209,7 @@ class ACLUserRules:
         """Simple shorthand to create the rule that the specified
            user is the writer of the resource
         """
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
         return ACLUserRules._create(aclrule=_ACLRule.writer(),
                                     user_guid=user_guid,
                                     user_guids=user_guids)
@@ -273,7 +219,7 @@ class ACLUserRules:
         """Simple shorthand to create the rule that the specified
            user is the reader of the resource
         """
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
         return ACLUserRules._create(aclrule=_ACLRule.reader(),
                                     user_guid=user_guid,
                                     user_guids=user_guids)
@@ -303,7 +249,7 @@ class ACLUserRules:
 
 def _is_inherit(aclrule):
     """Return whether or not this passed rule is just an inherit-all"""
-    from Acquire.Storage import ACLRule as _ACLRule
+    from Acquire.Identity import ACLRule as _ACLRule
 
     if isinstance(aclrule, _ACLRule):
         if aclrule == _ACLRule.inherit():
@@ -340,7 +286,14 @@ class ACLRules:
 
         if rules is not None:
             for rule in rules:
-                self.append(aclrule=rule[1], operation=rule[0])
+                try:
+                    aclrule = rule[1]
+                    oper = rule[0]
+                except:
+                    aclrule = rule
+                    oper = default_operation
+
+                self.append(aclrule=aclrule, operation=oper)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -362,21 +315,134 @@ class ACLRules:
         return "ACLRules{\n%s\n}" % "\n".join(s)
 
     @staticmethod
-    def owner(user_guid):
-        """Return the ACLRules for "user_guid" is the owner"""
-        from Acquire.Storage import ACLRule as _ACLRule
+    def _create(rule, user_guid=None, group_guid=None,
+                user_guids=None, group_guids=None,
+                default_rule=None):
+        """Create and return the ACLRules that applies 'rules' to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        from Acquire.Identity import ACLRule as _ACLRule
 
-        if user_guid is None:
-            return ACLRules(default_rule=_ACLRule.owner())
-        else:
-            user_rule = ACLUserRules()
-            user_rule.add_user_rule(user_guid=user_guid, rule=_ACLRule.owner())
-            return ACLRules(rule=user_rule, default_rule=_ACLRule.denied())
+        if default_rule is not None:
+            if not isinstance(default_rule, _ACLRule):
+                raise TypeError("The default_rule must be type ACLRule")
+
+        if user_guids is None:
+            user_guids = []
+
+        if group_guids is None:
+            group_guids = []
+
+        if user_guid is not None:
+            user_guids.append(user_guid)
+
+        if group_guid is not None:
+            group_guids.append(group_guid)
+
+        if len(user_guids) == 0 and len(group_guids) == 0:
+            if isinstance(rule, ACLRules):
+                # this is a copy constructor
+                return rule
+            else:
+                # no users or groups are specified - rule applies to everyone
+                return ACLRules(default_rule=rule)
+
+        if default_rule is None:
+            default_rule = _ACLRule.denied()
+
+        rules = []
+
+        if len(group_guids) > 0:
+            group_rules = ACLGroupRules()
+            group_rules.add_group_rule(group_guid, rule)
+            rules.append(group_rules)
+
+        if len(user_guids) > 0:
+            user_rules = ACLUserRules()
+            user_rules.add_user_rule(user_guid, rule)
+            rules.append(user_rules)
+
+        return ACLRules(rules=rules, default_rule=default_rule)
 
     @staticmethod
-    def inherit():
-        """Return the ACLRules for simple inherit"""
-        return ACLRules()
+    def create(rule, user_guid=None, user_guids=None,
+               group_guid=None, group_guids=None,
+               default_rule=None):
+        """Create and return the ACLRules that gives 'rule' to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        return ACLRules._create(user_guid=user_guid,
+                                user_guids=user_guids,
+                                group_guid=group_guid,
+                                group_guids=group_guids,
+                                default_rule=default_rule,
+                                rule=rule)
+
+    @staticmethod
+    def owner(user_guid=None, user_guids=None,
+              group_guid=None, group_guids=None,
+              default_rule=None):
+        """Create and return the ACLRules that gives ownership to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        from Acquire.Identity import ACLRule as _ACLRule
+        return ACLRules._create(user_guid=user_guid,
+                                user_guids=user_guids,
+                                group_guid=group_guid,
+                                group_guids=group_guids,
+                                default_rule=default_rule,
+                                rule=_ACLRule.owner())
+
+    @staticmethod
+    def reader(user_guid=None, user_guids=None,
+               group_guid=None, group_guids=None,
+               default_rule=None):
+        """Create and return the ACLRules that gives readership to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        from Acquire.Identity import ACLRule as _ACLRule
+        return ACLRules._create(user_guid=user_guid,
+                                user_guids=user_guids,
+                                group_guid=group_guid,
+                                group_guids=group_guids,
+                                default_rule=default_rule,
+                                rule=_ACLRule.reader())
+
+    @staticmethod
+    def writer(user_guid=None, user_guids=None,
+               group_guid=None, group_guids=None,
+               default_rule=None):
+        """Create and return the ACLRules that gives writership to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        from Acquire.Identity import ACLRule as _ACLRule
+        return ACLRules._create(user_guid=user_guid,
+                                user_guids=user_guids,
+                                group_guid=group_guid,
+                                group_guids=group_guids,
+                                default_rule=default_rule,
+                                rule=_ACLRule.writer())
+
+    @staticmethod
+    def inherit(user_guid=None, user_guids=None,
+                group_guid=None, group_guids=None,
+                default_rule=None):
+        """Create and return the ACLRules that sets inherit to
+           everyone specified (or to everyone, if this is not
+           specified)
+        """
+        from Acquire.Identity import ACLRule as _ACLRule
+        return ACLRules._create(user_guid=user_guid,
+                                user_guids=user_guids,
+                                group_guid=group_guid,
+                                group_guids=group_guids,
+                                default_rule=default_rule,
+                                rule=_ACLRule.inherit())
 
     def is_simple_inherit(self):
         """Return whether or not this set of rules is a simple
@@ -441,7 +507,7 @@ class ACLRules:
             if _is_inherit(aclrule):
                 return
             else:
-                from Acquire.Storage import ACLRule as _ACLRule
+                from Acquire.Identity import ACLRule as _ACLRule
                 self._is_simple_inherit = False
                 self._default_rule = None
                 self._rules = [_ACLRule.inherit()]
@@ -460,7 +526,7 @@ class ACLRules:
            in order (including the default rule, if set)
         """
         if self._is_simple_inherit:
-            from Acquire.Storage import ACLRule as _ACLRule
+            from Acquire.Identity import ACLRule as _ACLRule
             return [(self._default_operation, _ACLRule.inherit())]
         else:
             import copy as copy
@@ -476,7 +542,7 @@ class ACLRules:
            generated. If 'must_resolve' is True, then
            this is guaranteed to return a fully-resolved simple ACLRule
         """
-        from Acquire.Storage import ACLRule as _ACLRule
+        from Acquire.Identity import ACLRule as _ACLRule
 
         if self._is_simple_inherit:
             return _ACLRule.inherit().resolve(must_resolve=must_resolve,
@@ -487,8 +553,9 @@ class ACLRules:
 
         for rule in self._rules:
             if isinstance(rule, tuple):
-                op = rule[0]
-                rule = rule[1]
+                trule = tuple(rule)   # casting to stop linting error
+                op = trule[0]
+                rule = trule[1]
             else:
                 op = self._default_operation
 
@@ -551,9 +618,11 @@ class ACLRules:
             if "rules" in data:
                 rules = []
                 for rule in data["rules"]:
-                    if isinstance(rule, tuple):
-                        rules.append((ACLRuleOperation.from_data(rule[0]),
-                                      _load_rule(rule[1])))
+                    if isinstance(rule, dict):
+                        aclrule = rule["rule"]
+                        oper = rule["operation"]
+                        rules.append((ACLRuleOperation.from_data(oper),
+                                      _load_rule(aclrule)))
                     else:
                         rules.append((None, _load_rule(rule)))
             else:
@@ -572,12 +641,24 @@ class ACLRules:
 
         data = {}
 
-        if len(self._rules) > 0:
+        if len(self._rules) == 1:
+            rule = self._rules[0]
+            if isinstance(rule, tuple):
+                trule = tuple(rule)
+                rule = trule[1]
+
+            data["rules"] = [_save_rule(rule)]
+        elif len(self._rules) > 1:
             rules = []
 
             for rule in self._rules:
                 if isinstance(rule, tuple):
-                    rules.append((rule[0].to_data(), _save_rule(rule[1])))
+                    trule = tuple(rule)  # casting to stop linting error
+                    if trule[0] is None:
+                        rules.append(_save_rule(trule[1]))
+                    else:
+                        rules.append({"operation": trule[0].to_data(),
+                                      "rule": _save_rule(trule[1])})
                 else:
                     rules.append(_save_rule(rule))
 

--- a/Acquire/Storage/__init__.py
+++ b/Acquire/Storage/__init__.py
@@ -7,11 +7,11 @@ based on permissions routed via the access service
 
 """
 
+from Acquire.Identity import ACLRule, ACLRules
+
 from ._storage_service import *
 from ._errors import *
 from ._buckethandle import *
-from ._aclrule import *
-from ._aclrules import *
 from ._userdrives import *
 from ._fileinfo import *
 from ._driveinfo import *

--- a/Acquire/Storage/_driveinfo.py
+++ b/Acquire/Storage/_driveinfo.py
@@ -331,8 +331,8 @@ class DriveInfo:
         if self.is_null():
             return
 
-        from Acquire.Storage import create_aclrules as _create_aclrules
-        aclrules = _create_aclrules(aclrule=aclrule, user_guid=user_guid)
+        from Acquire.Identity import ACLRules as _ACLRules
+        aclrules = _ACLRules.create(user_guid=user_guid, rule=aclrule)
 
         # make sure we have the latest version
         self.load()
@@ -489,12 +489,11 @@ class DriveInfo:
                     "original request was not authorised by the user")
 
             # create a new drive and save it...
-            from Acquire.Storage import ACLRule as _ACLRule
-            from Acquire.Storage import create_aclrules as _create_aclrules
+            from Acquire.Identity import ACLRule as _ACLRule
+            from Acquire.Identity import ACLRules as _ACLRules
 
             # by default this user is the drive's owner
-            self._aclrules = _create_aclrules(user_guid=self._user_guid,
-                                              aclrule=_ACLRule.owner())
+            self._aclrules = _ACLRules.owner(user_guid=self._user_guid)
 
             data = self.to_data()
 

--- a/Acquire/Storage/_driveinfo.py
+++ b/Acquire/Storage/_driveinfo.py
@@ -46,7 +46,7 @@ class DriveInfo:
     """This class provides a service-side handle to the information
        about a particular cloud drive
     """
-    def __init__(self, drive_uid=None, user_guid=None,
+    def __init__(self, drive_uid=None, identifiers=None,
                  is_authorised=False, parent_drive_uid=None):
         """Construct a DriveInfo for the drive with UID 'drive_uid',
            and optionally the GUID of the user making the request
@@ -56,7 +56,7 @@ class DriveInfo:
         """
         self._drive_uid = drive_uid
         self._parent_drive_uid = parent_drive_uid
-        self._user_guid = user_guid
+        self._identifiers = identifiers
         self._is_authorised = is_authorised
 
         if self._drive_uid is not None:
@@ -159,11 +159,12 @@ class DriveInfo:
             if not isinstance(encrypt_key, _PublicKey):
                 raise TypeError("The encryption key must be of type PublicKey")
 
-        authorisation.verify("upload %s" % filehandle.fingerprint())
+        identifiers = authorisation.verify(
+                        resource="upload %s" % filehandle.fingerprint(),
+                        return_identifiers=True)
 
-        user_guid = authorisation.user_guid()
-
-        drive_acl = self.aclrules().resolve(user_guid=user_guid)
+        drive_acl = self.aclrules().resolve(identifiers=identifiers,
+                                            must_resolve=True)
 
         if not drive_acl.is_writeable():
             raise PermissionError(
@@ -173,11 +174,12 @@ class DriveInfo:
         # now generate a FileInfo for this FileHandle
         fileinfo = _FileInfo(drive_uid=self._drive_uid,
                              filehandle=filehandle,
-                             user_guid=authorisation.user_guid())
+                             identifiers=identifiers,
+                             upstream=drive_acl)
 
         # resolve the ACL for the file from this FileHandle
-        file_acl = fileinfo.aclrules().resolve(upstream=drive_acl,
-                                               user_guid=user_guid)
+        filemeta = fileinfo.get_filemeta()
+        file_acl = filemeta.acl()
 
         if not file_acl.is_writeable():
             raise PermissionError(
@@ -222,13 +224,16 @@ class DriveInfo:
 
         # now save the fileinfo to the object store
         fileinfo.save()
+        filemeta = fileinfo.get_filemeta()
+
+        assert(filemeta.acl().is_owner())
 
         # return the PAR if we need to have a second-stage of upload
-        return (fileinfo.get_filemeta(resolved_acl=file_acl), par)
+        return (filemeta, par)
 
     def download(self, filename, authorisation,
                  version=None, encrypt_key=None,
-                 **kwargs):
+                 force_par=False):
         """Download the file called filename. This will return a
            FileHandle that describes the file. If the file is
            sufficiently small, then the filedata will be embedded
@@ -252,23 +257,26 @@ class DriveInfo:
         if not isinstance(encrypt_key, _PublicKey):
             raise TypeError("The encryption key must be of type PublicKey")
 
-        authorisation.verify("download %s %s" % (self._drive_uid,
-                                                 filename))
+        identifiers = authorisation.verify(
+                    resource="download %s %s" % (self._drive_uid, filename),
+                    return_identifiers=True)
 
-        user_guid = authorisation.user_guid()
-
-        drive_acl = self.aclrules().resolve(user_guid=user_guid)
+        drive_acl = self.aclrules().resolve(identifiers=identifiers,
+                                            must_resolve=True)
 
         # even if the drive_acl is not readable by this user, they
         # may have read permission for the file...
 
         # now get the FileInfo for this FileHandle
         fileinfo = _FileInfo.load(drive=self,
-                                  filename=filename, version=version)
+                                  filename=filename,
+                                  version=version,
+                                  identifiers=self._identifiers,
+                                  upstream=drive_acl)
 
         # resolve the ACL for the file from this FileHandle
-        file_acl = fileinfo.aclrules().resolve(upstream=drive_acl,
-                                               user_guid=user_guid)
+        filemeta = fileinfo.get_filemeta()
+        file_acl = filemeta.acl()
 
         if not file_acl.is_readable():
             raise PermissionError(
@@ -280,11 +288,6 @@ class DriveInfo:
         file_key = fileinfo.latest_version()._file_key()
         filedata = None
         par = None
-
-        if "force_par" in kwargs:
-            force_par = kwargs["force_par"]
-        else:
-            force_par = None
 
         if force_par or fileinfo.filesize() > 1048576:
             # the file is too large to include in the download so
@@ -299,17 +302,17 @@ class DriveInfo:
             filedata = _ObjectStore.get_object(file_bucket, file_key)
 
         # return the filemeta, and either the filedata or par
-        return (fileinfo.get_filemeta(resolved_acl=file_acl), filedata, par)
+        return (filemeta, filedata, par)
 
     def is_opened_by_owner(self):
         """Return whether or not this drive was opened and authorised
            by one of the drive owners
         """
-        if self._user_guid is None or (not self._is_authorised):
+        if self._identifiers is None or (not self._is_authorised):
             return False
 
         try:
-            return self._acls[self._user_guid].is_owner()
+            return self.aclrules().resolve(identifiers=identifiers).is_owner()
         except:
             return False
 
@@ -355,19 +358,19 @@ class DriveInfo:
            in this Drive. The passed authorisation is needed in case
            the list contents of this drive is not public
         """
-        user_guid = None
-
         if authorisation is not None:
             from Acquire.Client import Authorisation as _Authorisation
             if not isinstance(authorisation, _Authorisation):
                 raise TypeError(
                     "The authorisation must be of type Authorisation")
 
-            authorisation.verify("list_files")
+            identifiers = authorisation.verify(resource="list_files",
+                                               return_identifiers=True)
+        else:
+            identifiers = self._identifiers
 
-            user_guid = authorisation.user_guid()
-
-        drive_acl = self.aclrules().resolve(user_guid=user_guid)
+        drive_acl = self.aclrules().resolve(identifiers=identifiers,
+                                            must_resolve=True)
 
         if not drive_acl.is_readable():
             raise PermissionError(
@@ -393,10 +396,11 @@ class DriveInfo:
             for name in names:
                 data = _ObjectStore.get_object_from_json(metadata_bucket,
                                                          name)
-                fileinfo = _FileInfo.from_data(data)
+                fileinfo = _FileInfo.from_data(data,
+                                               identifiers=identifiers,
+                                               upstream=drive_acl)
                 filemeta = fileinfo.get_filemeta()
-                file_acl = filemeta.resolve_acl(upstream=drive_acl,
-                                                user_guid=user_guid)
+                file_acl = filemeta.acl()
 
                 if file_acl.is_readable() or file_acl.is_writeable():
                     files.append(filemeta)
@@ -408,14 +412,14 @@ class DriveInfo:
         return files
 
     def list_versions(self, filename, authorisation=None,
-                      include_metadata=False, **kwargs):
+                      include_metadata=False):
         """Return the list of versions of the file with specified
            filename. If 'include_metadata' is true then this will
            load full metadata for each version. This will return
            a sorted list of FileMeta objects. The passed authorisation
            is needed in case the version info is not public
         """
-        user_guid = None
+        identifiers = None
 
         if authorisation is not None:
             from Acquire.Client import Authorisation as _Authorisation
@@ -423,11 +427,12 @@ class DriveInfo:
                 raise TypeError(
                     "The authorisation must be of type Authorisation")
 
-            authorisation.verify("list_versions %s" % filename)
+            identifiers = authorisation.verify(
+                            resource="list_versions %s" % filename,
+                            return_identifiers=True)
 
-            user_guid = authorisation.user_guid()
-
-        drive_acl = self.aclrules().resolve(user_guid=user_guid, **kwargs)
+        drive_acl = self.aclrules().resolve(identifiers=identifiers,
+                                            must_resolve=True)
 
         if not drive_acl.is_readable():
             raise PermissionError(
@@ -436,15 +441,19 @@ class DriveInfo:
         from Acquire.Storage import FileInfo as _FileInfo
         versions = _FileInfo.list_versions(drive=self,
                                            filename=filename,
+                                           identifiers=identifiers,
+                                           upstream=drive_acl,
                                            include_metadata=include_metadata)
 
         result = []
 
         for version in versions:
-            if version.aclrules() is not None:
-                acl = version.resolve_acl(upstream=drive_acl,
-                                          user_guid=user_guid,
-                                          **kwargs)
+            aclrules = version.aclrules()
+            if aclrules is not None:
+                acl = aclrules.resolve(upstream=drive_acl,
+                                       identifiers=identifiers,
+                                       must_resolve=True,
+                                       unresolved=False)
 
                 if acl.is_readable() or acl.is_writeable():
                     result.append(version)
@@ -452,9 +461,9 @@ class DriveInfo:
                 result.append(version)
 
         # return the versions sorted in upload order
-        versions.sort(key=lambda x: x.uploaded_when())
+        result.sort(key=lambda x: x.uploaded_when())
 
-        return versions
+        return result
 
     def load(self):
         """Load the metadata about this drive from the object store"""
@@ -475,7 +484,13 @@ class DriveInfo:
             data = None
 
         if data is None:
-            if self._user_guid is None:
+            # by default this user is the drive's owner
+            try:
+                user_guid = self._identifiers["user_guid"]
+            except:
+                user_guid = None
+
+            if user_guid is None:
                 # we cannot create the drive as we don't know who
                 # requested it
                 raise PermissionError(
@@ -492,8 +507,7 @@ class DriveInfo:
             from Acquire.Identity import ACLRule as _ACLRule
             from Acquire.Identity import ACLRules as _ACLRules
 
-            # by default this user is the drive's owner
-            self._aclrules = _ACLRules.owner(user_guid=self._user_guid)
+            self._aclrules = _ACLRules.owner(user_guid=user_guid)
 
             data = self.to_data()
 
@@ -503,12 +517,12 @@ class DriveInfo:
         from copy import copy as _copy
         other = DriveInfo.from_data(data)
 
-        user_guid = self._user_guid
+        identifiers = self._identifiers
         is_authorised = self._is_authorised
 
         self.__dict__ = _copy(other.__dict__)
 
-        self._user_guid = user_guid
+        self._identifiers = identifiers
         self._is_authorised = is_authorised
 
     def save(self):

--- a/Acquire/Storage/_fileinfo.py
+++ b/Acquire/Storage/_fileinfo.py
@@ -32,9 +32,8 @@ class VersionInfo:
                     "uploading this version of the file!")
 
             if aclrules is None:
-                from Acquire.Storage import create_aclrules as _create_aclrules
-                from Acquire.Storage import ACLRule as _ACLRule
-                aclrules = _create_aclrules(aclrule=_ACLRule.inherit())
+                from Acquire.Identity import ACLRules as _ACLRules
+                aclrules = _ACLRules.inherit()
             else:
                 if not isinstance(aclrules, _ACLRules):
                     raise TypeError("The aclrules must be type ACLRules")

--- a/Acquire/Storage/_filemeta.py
+++ b/Acquire/Storage/_filemeta.py
@@ -151,35 +151,21 @@ class FileMeta:
         except:
             return None
 
-    def resolve_acl(self, **kwargs):
+    def resolve_acl(self, identifiers=None, upstream=None,
+                    must_resolve=None, unresolved=False):
         """Resolve the ACL for this file based on the passed arguments
            (same as for ACLRules.resolve()). This returns the resolved
            ACL, which is set as self.acl()
         """
-        if "resolved_acl" in kwargs:
-            acl = kwargs["resolved_acl"]
-            from Acquire.Storage import ACLRule as _ACLRule
-            if not isinstance(acl, _ACLRule):
-                raise TypeError(
-                    "The resolved ACL must be type ACLRule")
-
-            self._acl = acl.resolve(must_resolve=True, **kwargs)
-
-            if not self._acl.is_owner():
-                # only owners can see the ACLs
-                self._aclrules = None
-
-            if self._acl.denied_all():
-                # not allowed to know anythign about the file
-                self._set_denied()
-
-            return self._acl
-
-        if self._aclrules is None:
+        aclrules = self.aclrules()
+        if aclrules is None:
             raise PermissionError(
                 "You do not have permission to resolve the ACLs for this file")
 
-        self._acl = self._aclrules.resolve(**kwargs)
+        self._acl = aclrules.resolve(must_resolve=must_resolve,
+                                     identifiers=identifiers,
+                                     upstream=upstream,
+                                     unresolved=unresolved)
 
         if not self._acl.is_owner():
             # only owners can see the ACLs

--- a/Acquire/Storage/_userdrives.py
+++ b/Acquire/Storage/_userdrives.py
@@ -23,7 +23,8 @@ class UserDrives:
                     "You can only authorise UserDrives with a valid "
                     "Authorisation object")
 
-            authorisation.verify(resource="UserDrives")
+            self._identifiers = authorisation.verify(resource="UserDrives",
+                                                     return_identifiers=True)
 
             self._is_authorised = True
 
@@ -37,6 +38,7 @@ class UserDrives:
         else:
             self._user_guid = str(user_guid)
             self._is_authorised = False
+            self._identifiers = None
 
     def is_null(self):
         """Return whether or not this is null"""
@@ -115,7 +117,8 @@ class UserDrives:
 
         if drive_uid is not None:
             from Acquire.Storage import DriveInfo as _DriveInfo
-            drive = _DriveInfo(drive_uid=drive_uid, user_guid=self._user_guid,
+            drive = _DriveInfo(drive_uid=drive_uid,
+                               identifiers=self._identifiers,
                                is_authorised=self._is_authorised)
         else:
             drive = None
@@ -133,7 +136,7 @@ class UserDrives:
 
                 from Acquire.Storage import DriveInfo as _DriveInfo
                 drive = _DriveInfo(drive_uid=drive_uid,
-                                   user_guid=self._user_guid,
+                                   identifiers=self._identifiers,
                                    is_authorised=self._is_authorised)
 
         return drive
@@ -180,8 +183,9 @@ class UserDrives:
 
         if drive_uid is not None:
             from Acquire.Storage import DriveInfo as _DriveInfo
-            drive = _DriveInfo(drive_uid=drive_uid, user_guid=self._user_guid,
-                               is_authorised=self._is_authorised)
+            drive = _DriveInfo(drive_uid=drive_uid,
+                               is_authorised=self._is_authorised,
+                               identifiers=self._identifiers)
         else:
             drive = None
 
@@ -198,7 +202,7 @@ class UserDrives:
 
                 from Acquire.Storage import DriveInfo as _DriveInfo
                 drive = _DriveInfo(drive_uid=drive_uid,
-                                   user_guid=self._user_guid,
+                                   identifiers=self._identifiers,
                                    is_authorised=self._is_authorised)
 
         if drive is None:
@@ -225,6 +229,10 @@ class UserDrives:
 
         from Acquire.Storage import DriveMeta as _DriveMeta
 
-        return _DriveMeta(name=drive_name, uid=drive.uid(),
-                          container=container,
-                          aclrules=drive.aclrules())
+        drivemeta = _DriveMeta(name=drive_name, uid=drive.uid(),
+                               container=container,
+                               aclrules=drive.aclrules())
+
+        drivemeta.resolve_acl(identifiers=self._identifiers)
+
+        return drivemeta

--- a/services/storage/download.py
+++ b/services/storage/download.py
@@ -44,8 +44,7 @@ def run(args):
     if force_par:
         force_par = True
 
-    drive = DriveInfo(drive_uid=drive_uid,
-                      user_guid=authorisation.user_guid())
+    drive = DriveInfo(drive_uid=drive_uid)
 
     return_value = create_return_value()
 

--- a/services/storage/list_files.py
+++ b/services/storage/list_files.py
@@ -26,7 +26,7 @@ def run(args):
     else:
         include_metadata = False
 
-    drive = DriveInfo(drive_uid=drive_uid, user_guid=authorisation.user_guid())
+    drive = DriveInfo(drive_uid=drive_uid)
 
     files = drive.list_files(authorisation=authorisation,
                              include_metadata=include_metadata)

--- a/services/storage/list_versions.py
+++ b/services/storage/list_versions.py
@@ -27,7 +27,7 @@ def run(args):
     else:
         include_metadata = False
 
-    drive = DriveInfo(drive_uid=drive_uid, user_guid=authorisation.user_guid())
+    drive = DriveInfo(drive_uid=drive_uid)
 
     versions = drive.list_versions(authorisation=authorisation,
                                    filename=filename,

--- a/services/storage/open_drive.py
+++ b/services/storage/open_drive.py
@@ -30,8 +30,6 @@ def run(args):
 
     drive = drives.get_drive(name=name, autocreate=autocreate)
 
-    drive.resolve_acl(user_guid=authorisation.user_guid())
-
     return_value = create_return_value()
 
     return_value["drive"] = drive.to_data()

--- a/services/storage/upload.py
+++ b/services/storage/upload.py
@@ -38,8 +38,7 @@ def run(args):
 
     drive_uid = filehandle.drive_uid()
 
-    drive = DriveInfo(drive_uid=drive_uid,
-                      user_guid=authorisation.user_guid())
+    drive = DriveInfo(drive_uid=drive_uid)
 
     return_value = create_return_value()
 

--- a/test/mock/identity/test_acls.py
+++ b/test/mock/identity/test_acls.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-from Acquire.Storage import ACLRule, ACLRules, ACLGroupRules, ACLUserRules
+from Acquire.Identity import ACLRule, ACLRules, ACLGroupRules, ACLUserRules
 
 
 def test_acls():
@@ -53,3 +53,6 @@ def test_acls():
 
     assert(rules.resolve(user_guid=user_guid).is_owner())
     assert(rules.resolve(user_guid=user_guid2).denied_all())
+
+    data = ACLRules.inherit().to_data()
+    assert(ACLRules.from_data(data).is_simple_inherit())

--- a/test/mock/identity/test_acls.py
+++ b/test/mock/identity/test_acls.py
@@ -34,25 +34,30 @@ def test_acls():
     assert(rules.is_simple_inherit())
 
     user_guid = "someone@somewhere"
-
-    rule = rules.resolve(user_guid=user_guid, must_resolve=False)
-    assert(rule.inherits_all())
-
-    user_rule = ACLUserRules.owner(user_guid=user_guid)
-    assert(user_rule.resolve(user_guid=user_guid).is_owner())
-
-    rules = ACLRules(rule=user_rule, default_rule=ACLRule.denied())
-    assert(rules.resolve(user_guid=user_guid).is_owner())
+    identifiers = {"user_guid": user_guid}
 
     user_guid2 = "someone_else@somewhere"
-    assert(rules.resolve(user_guid=user_guid2).denied_all())
+    identifiers2 = {"user_guid": user_guid2}
+
+    rule = rules.resolve(identifiers=identifiers, must_resolve=False)
+    assert(rule.inherits_all())
+
+    rule = rules.resolve(identifiers=identifiers2, must_resolve=True)
+    assert(rule.denied_all())
+
+    user_rule = ACLUserRules.owner(user_guid=user_guid)
+    assert(user_rule.resolve(identifiers=identifiers).is_owner())
+
+    rules = ACLRules(rule=user_rule, default_rule=ACLRule.denied())
+    assert(rules.resolve(identifiers=identifiers).is_owner())
+    assert(rules.resolve(identifiers=identifiers2).denied_all())
 
     data = rules.to_data()
 
     rules = ACLRules.from_data(data)
 
-    assert(rules.resolve(user_guid=user_guid).is_owner())
-    assert(rules.resolve(user_guid=user_guid2).denied_all())
+    assert(rules.resolve(identifiers=identifiers).is_owner())
+    assert(rules.resolve(identifiers=identifiers2).denied_all())
 
     data = ACLRules.inherit().to_data()
     assert(ACLRules.from_data(data).is_simple_inherit())


### PR DESCRIPTION
Merging in changes related to better handling of ACLs. Authorisation now returns the "identifiers" for the user who provided the authorisation. These are now more consistently passed through the ACLs to resolve (together with upstream) into a concrete ACLRule to control access.