### PR TITLE
Fix for final test failing in test_drives.py

### DIFF
--- a/test/mock/storage/test_drives.py
+++ b/test/mock/storage/test_drives.py
@@ -182,8 +182,7 @@ def test_drives(authenticated_user, tempdir):
     assert(versions[0] == filemeta)
     assert(versions[1] == new_filemeta)
 
-    (filename, new_filemeta) = drive.download(filemeta.filename(),
-                                              dir=tempdir, force_par=True)
+    (filename, new_filemeta) = drive.download(filemeta.filename(), dir=tempdir)
 
     # make sure that the two files are identical
     with open(filename, "rb") as FILE:


### PR DESCRIPTION
Before the final assert in test_drives.py the download function was being passed `force_par=True` resulting in the file being returned incorrectly